### PR TITLE
ESM only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
   "name": "@beyonk/svelte-facebook-pixel",
   "type": "module",
-  "svelte": "src/index.js",
-  "module": "dist/index.mjs",
-  "main": "dist/index.js",
+  "exports": "src/index.js",
   "scripts": {
     "dev": "WATCH=true nollup -c --hot --port 5000 --content-base ./public -s",
     "build": "rollup -c",
-    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext .svelte,.html,.js"
   },
   "devDependencies": {
@@ -35,8 +32,7 @@
     "svelte"
   ],
   "files": [
-    "src",
-    "dist"
+    "src"
   ],
   "version": "3.0.2"
 }


### PR DESCRIPTION
I realized my last PR fixed the `svelte` field, but broke the `main` field. Oops!  Really Svelte components should not distribute CJS versions or even need to be built most of the time. This is a cleaner setup. I left the Rollup config file and build steps for now because the example was using them, but you don't need them for the library itself